### PR TITLE
Added a drop down menu to show finance and marketing reports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "java.project.referencedLibraries": [
+        "lib/**/*.jar",
+        "App/lib/mysql-connector-java-8.0.28.jar"
+    ]
+}

--- a/app/src/main/java/com/yagni/view/OrdersGUI.java
+++ b/app/src/main/java/com/yagni/view/OrdersGUI.java
@@ -197,6 +197,22 @@ public class OrdersGUI implements ActionListener,FocusListener,MouseListener{
 		ordersFrame.add(bodyPanel);
 		ordersFrame.add(footerPanel, BorderLayout.SOUTH);
 
+		 //Menu to show reports and its items
+		 JMenuBar menubar = new JMenuBar();
+		 ordersFrame.setJMenuBar(menubar);
+
+		 JMenu MarketReports = new JMenu("Marketing Reports");
+		 menubar.add(MarketReports);
+		 JMenuItem daily = new JMenuItem("Daily report");  
+		 JMenuItem weekly = new JMenuItem("Weekly report"); 
+		 JMenuItem monthly = new JMenuItem("Monthly report");
+		 MarketReports.add(daily);
+		 MarketReports.add(weekly);   
+		 MarketReports.add(monthly);
+
+		 JMenu FinanceReports = new JMenu("Finance Reports");
+		 menubar.add(FinanceReports);
+		 
 		//displays all content to the GUI 
 		ordersFrame.setVisible(true);
 	}


### PR DESCRIPTION
I added drop down menu for finance reports and marketing reports. This is only the start of it but I am pushing this to let @S4kRiPp4 use it as a reference. 
<img width="840" alt="Screen Shot 2022-04-09 at 9 41 16 PM" src="https://user-images.githubusercontent.com/98117780/163440809-d4dc0bc7-15b7-4483-b785-7c20743ad4df.png">
